### PR TITLE
discover and simulate updates

### DIFF
--- a/rp-start-discover.adoc
+++ b/rp-start-discover.adoc
@@ -25,7 +25,7 @@ You can do the following:
 //* During workload discovery, you can enable automatic discovery of workloads per Connector. This feature lets you select the workloads that you want to protect. 
 * Discover newly created workloads for previously selected working environments. 
 
-* Select _new_ working environments. This feature helps you protect new workloads that are added to your environment.
+
 
 == Select workloads to discover and protect
 Within each Connector, select the working environments where you want to discover workloads. 
@@ -88,9 +88,9 @@ If you have already selected working environments for discovery, you can discove
 . From the Dashboard, select the *Refresh icon* which initiates discovery of new workloads. 
 
 
-== Discover newly created working environments
+== Discover new working environments
 
-If you have already discovered working environments, you can discover any newly created working environments from the Dashboard.
+If you have already discovered working environments, you can discover any newly created working environments or working environments that you did not previously select during previous discovery processes.
 
 .Steps
 
@@ -100,6 +100,8 @@ If you have already discovered working environments, you can discover any newly 
 . From the BlueXP ransomware protection menu, select the vertical image:button-actions-vertical.png[Vertical Actions]... option at the top right. From the drop-down menu, select *Settings*. 
 
 . In the Workload discovery card, select *Discover workloads*.
++
+TIP: This process might take a few minutes as indicated by an in-process loading icon.
 
 //== Enable automatic discovery of workloads per Connector
 

--- a/rp-start-simulate.adoc
+++ b/rp-start-simulate.adoc
@@ -35,8 +35,8 @@ image:screen-settings-alert-drill-configure.png[Configure readiness drill page]
 . Enter the name of a new test workload to be created. 
 
 . Select *Save*.
-+ 
-A message appears that the readiness drill environment is configured. In that message, select *Start readiness drill* to start the drill.
+//+ 
+//A message appears that the readiness drill environment is configured. In that message, select *Start readiness drill* to start the drill.
 
 TIP: You can edit the readiness drill configuration later using the Settings page. 
 
@@ -51,18 +51,15 @@ After you configure the readiness drill, you can start the drill.
 * From the BlueXP ransomware protection Settings menu, select *Readiness drill* and then in the Readiness drill page, select *Start*.
 +
 * OR, from the Settings page, in the Readiness drill card, select *Start*.
+//. Do one of the following:
+//* If you haven't already configured the readiness drill, a message appears that you first need to configure the readiness drill.
+//+
+//image:screen-settings-alert-drill-needtoconfigure.png[Settings page showing the readiness drill message that you need to configure the readiness drill]
+//+
+//** Select *Configure readiness drill test environment*. 
+//** Continue with the instructions in the previous section to configure the drill test environment in the Settings option.
 
-
-. Do one of the following:
-
-* If you haven't already configured the readiness drill, a message appears that you first need to configure the readiness drill.
-+
-image:screen-settings-alert-drill-needtoconfigure.png[Settings page showing the readiness drill message that you need to configure the readiness drill]
-+
-** Select *Configure readiness drill test environment*. 
-** Continue with the instructions in the previous section to configure the drill test environment in the Settings option.
-
-* If you already configured the readiness drill, after selecting *Start*, the readiness drill begins.  
+. If you already configured the readiness drill, after selecting *Start*, the readiness drill begins.  
 //+
 //image:screen-settings-alert-drill-start.png[Start readiness drill page]
 
@@ -119,7 +116,7 @@ image:screen-alerts-readiness-incidents2.png[Incident page showing the readiness
 Here are some things to look for:
 
 * Look at the Potential attack Type. If the Type indicates that a user is suspected of malicious activity, review the user name. 
-** You might want to block the user by selecting *Block user*. 
+//** You might want to block the user by selecting *Block user*. 
 ** You might also want to investigate the user more in Data Infrastructure Insights Workload Security by selecting *Investigate in Workload security*. 
 
 


### PR DESCRIPTION
Comments from S. 
This pull request includes changes to the documentation files `rp-start-discover.adoc` and `rp-start-simulate.adoc` to improve clarity and update instructions. The most important changes include removing redundant information, updating section titles for consistency, adding tips for better user guidance, and commenting out unnecessary details.

Documentation improvements:

* [`rp-start-discover.adoc`](diffhunk://#diff-836c40ce1757fb54cf671ebfa2a3d2da7e284c64ab3d9813317e63747d923a87L28-R28): Removed redundant information about selecting new working environments.
* [`rp-start-discover.adoc`](diffhunk://#diff-836c40ce1757fb54cf671ebfa2a3d2da7e284c64ab3d9813317e63747d923a87L91-R93): Updated section title from "Discover newly created working environments" to "Discover new working environments" for consistency.
* [`rp-start-discover.adoc`](diffhunk://#diff-836c40ce1757fb54cf671ebfa2a3d2da7e284c64ab3d9813317e63747d923a87R103-R104): Added a tip to inform users that the discovery process might take a few minutes.
* [`rp-start-simulate.adoc`](diffhunk://#diff-b1ec7194ed2a30c092011954ce754d6ef2717111e0b62569a686f8bca1cd8405L38-R39): Removed unnecessary details about the readiness drill configuration message. [[1]](diffhunk://#diff-b1ec7194ed2a30c092011954ce754d6ef2717111e0b62569a686f8bca1cd8405L38-R39) [[2]](diffhunk://#diff-b1ec7194ed2a30c092011954ce754d6ef2717111e0b62569a686f8bca1cd8405R54-R62)
* [`rp-start-simulate.adoc`](diffhunk://#diff-b1ec7194ed2a30c092011954ce754d6ef2717111e0b62569a686f8bca1cd8405L122-R119): Rem the suggestion to block a user suspected of malicious activity.