### PR TITLE
Bluexpdoc-664 // update FAQ location in sidebar

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -36,8 +36,6 @@ sidebar:
           url: /rp-start-simulate.html  
         - title: Configure backups, threat detection, & attack simulations in Settings 
           url: /rp-use-settings.html 
-        - title: FAQ
-          url: /rp-start-faq.html
     - title: Use BlueXP ransomware protection
       entries:
         - title: Use BlueXP ransomware protection overview
@@ -65,6 +63,8 @@ sidebar:
 #      entries:
 #        - title: Role-based access control privileges
 #          url: /rp-reference-roles.html
+    - title: FAQ
+      url: /rp-start-faq.html
     - title: Legal notices
       url: /legal-notices.html
 product-family:


### PR DESCRIPTION
This pull request makes a minor adjustment to the sidebar navigation in `project.yml`. The main change is moving the "FAQ" entry to a different section for better organization.

* Sidebar navigation update:
  * Relocated the "FAQ" item from the "Configure backups, threat detection, & attack simulations in Settings" section to the main sidebar, placing it just above "Legal notices". (`project.yml`) [[1]](diffhunk://#diff-4f3430205157bae48d1786fcd16dbaaa50f9a1dc46b93ff9ccd26487c269b317L39-L40) [[2]](diffhunk://#diff-4f3430205157bae48d1786fcd16dbaaa50f9a1dc46b93ff9ccd26487c269b317R66-R67)